### PR TITLE
ts7250v3: Add ${nfsroot_options} to nfsboot env string

### DIFF
--- a/include/configs/ts7250v3.h
+++ b/include/configs/ts7250v3.h
@@ -60,7 +60,7 @@
 		"dhcp;" \
 		"nfs ${fdt_addr_r} ${nfsroot}/boot/" CONFIG_DEFAULT_DEVICE_TREE ".dtb;" \
 		"nfs ${kernel_addr_r} ${nfsroot}/boot/zImage;" \
-		"setenv bootargs root=/dev/nfs rw ip=dhcp nfsroot=${nfsroot} " \
+		"setenv bootargs root=/dev/nfs rw ip=dhcp nfsroot=${nfsroot}${nfsroot_options} " \
 			"loglevel=4 console=${console};" \
 		"bootz ${kernel_addr_r} - ${fdt_addr_r};\0" \
 	BOOTENV


### PR DESCRIPTION
nfsboot uses the value of ${nfsroot} as both a path and as the value of the parameter (also named nfsroot, confusingly enough) that is passed as an argument when starting the kernel. To the kernel, the nfsroot parameter doesn't only represent a path, it is also a comma-separated list of [NFS options](https://www.kernel.org/doc/html/latest/admin-guide/nfs/nfsroot.html#kernel-command-line).

Depending on the server and its configuration, one of these options, vers=3, may be required in order for the client to successfully NFS mount its root filesystem. Including it as part of ${nfsroot} would corrupt its meaning when nfsboot uses it as a path. The simplest solution is to introduce ${nfsboot_options} as a suffix, so that if the need to pass additional options arises, one need only define it in the environment:

> env set nfsboot_options ",vers=3"

**Note the leading comma is required**. It is there to provide the comma-separation between that option and the <root-dir> that precedes it.
