### PR TITLE
ts4100/post: Update eMMC test output

### DIFF
--- a/board/technologic/ts4100/post.c
+++ b/board/technologic/ts4100/post.c
@@ -83,6 +83,11 @@ int emmc_test(int destructive)
 
 	/* This tests simple enumeration */
 	ret |= cmd->cmd(cmd, 0, 3, query_argv);
+	if (ret) {
+		printf("eMMC failed to enumerate\n");
+		printf("eMMC test failed\n");
+		return ret;
+	}
 
 	if(destructive) {
 		memset(loadaddr, 0xAAAAAAAA, 1024*1024*4);
@@ -111,11 +116,12 @@ int emmc_test(int destructive)
 			}
 		}
 
-		if (ret == 0) printf("eMMC test passed\n");
-		else printf("eMMC test failed\n");
 	} else {
-		printf("Not running eMMC test!\n");
+		printf("Not running destructive eMMC test!\n");
 	}
+
+	if (ret == 0) printf("eMMC test passed\n");
+	else printf("eMMC test failed\n");
 
 	return ret;
 }


### PR DESCRIPTION
There was previously a gap in the output that caused a non-destructive test to silently fail if the eMMC device failed to enumerate. Now, fail immediately if enumeration fails, and always report success along with if the destructive test was skipped.

This might be worth investigating and changing on other products.

Only affects production, does not affect end user cases.