### PR TITLE
ts7250v3: mfg: Nix duplicated function call

### DIFF
--- a/board/technologic/ts7250v3/mfg.c
+++ b/board/technologic/ts7250v3/mfg.c
@@ -104,12 +104,6 @@ int setup_emmc(void)
 		return 1;
 	}
 
-	ret = mmc_set_boot_bus_width(mmc, 1, 0, 2);
-	if(ret) {
-		printf("emmc bootbus failed\n");
-		return 1;
-	}
-
 	ret = mmc_set_part_conf(mmc, 1, 1, 1);
 	if(ret) {
 		printf("emmc partconf failed\n");


### PR DESCRIPTION
Duplicated calls to mmc_set_boot_bus_width() serve no purpose. Pull this commit if I'm not wrong :-)