### PR TITLE
tools: fix cross-compiling tools when HOSTCC is overridden

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -225,7 +225,7 @@ $(LOGO_DATA_H):	$(obj)/bmp_logo $(LOGO_BMP)
 subdir- += env
 
 ifneq ($(CROSS_BUILD_TOOLS),)
-HOSTCC = $(CC)
+override HOSTCC = $(CC)
 
 quiet_cmd_crosstools_strip = STRIP   $^
       cmd_crosstools_strip = $(STRIP) $^; touch $@

--- a/tools/env/Makefile
+++ b/tools/env/Makefile
@@ -8,7 +8,7 @@
 # fw_printenv is supposed to run on the target system, which means it should be
 # built with cross tools. Although it may look weird, we only replace "HOSTCC"
 # with "CC" here for the maximum code reuse of scripts/Makefile.host.
-HOSTCC = $(CC)
+override HOSTCC = $(CC)
 
 # Compile for a hosted environment on the target
 HOST_EXTRACFLAGS  = $(patsubst -I%,-idirafter%, $(filter -I%, $(UBOOTINCLUDE))) \


### PR DESCRIPTION
[backported commit from mainline U-Boot]

Richard reported U-Boot tools issues in OpenEmbedded/Yocto project.

OE needs to be able to change the default compiler. If we pass in HOSTCC through the make command, it overwrites all HOSTCC instances, including ones in tools/Makefile and tools/env/Makefile, which breaks "make cross_tools" and "make env", respectively.

Add "override" directives to avoid overriding HOSTCC instances that really need to point to the cross-compiler.

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>
Reported-by: Richard Purdie <richard.purdie@linuxfoundation.org>
Reviewed-by: Simon Glass <sjg@chromium.org>