### PR TITLE
TS-7250-V3: fix initrd high

### DIFF
--- a/include/configs/ts7250v3.h
+++ b/include/configs/ts7250v3.h
@@ -42,6 +42,8 @@
 #define RAMDISK_ADDR_R			0x90000000
 
 #define CONFIG_EXTRA_ENV_SETTINGS \
+	"fdt_high=0xffffffff\0" \
+	"initrd_high=0xffffffff\0" \
 	"autoload=no\0" \
 	"netretry=once\0" \
 	"clearenv=mmc dev 0 1; mmc erase 800 2000; mmc erase C00 2000;\0" \


### PR DESCRIPTION
Set these to 0xffffffff to prevent relocation and use the u-boot addresses directly