### PR TITLE
TS-7100/TS-7180 dtb fixup

### DIFF
--- a/board/technologic/ts7100/ts7100.c
+++ b/board/technologic/ts7100/ts7100.c
@@ -464,7 +464,7 @@ static int fixup_ism330(void *blob)
 	ret = dm_i2c_read(chip, 0x0f, &value, 1);
 	if (ret) {
 		printf("fixup_ism330: No IMU found\n");
-		return 1;
+		return 0;
 	}
 	switch (value) {
 		case 0x6b:

--- a/board/technologic/ts7180/ts7180.c
+++ b/board/technologic/ts7180/ts7180.c
@@ -517,7 +517,7 @@ static int fixup_ism330(void *blob)
 	ret = dm_i2c_read(chip, 0x0f, &value, 1);
 	if (ret) {
 		printf("fixup_ism330: No IMU found\n");
-		return 1;
+		return 0;
 	}
 	switch (value) {
 		case 0x6b:


### PR DESCRIPTION
The last changes to ft_board_setup actually started using the return result of fixup_ism330.  In general we want to fail if these fixup fail, but we should not fail if this is on a model that doesn't include that population option.

This fixes:

fixup_ism330: No IMU found
ERROR: board-specific fdt fixup failed: <valid offset/length>
 - must RESET the board to recover.

FDT creation failed! hanging...### ERROR ### Please RESET the board ###
