### PR TITLE
board: ts7100: disable duplicate wdog1 node

### DIFF
--- a/arch/arm/dts/imx6ul-ts7100.dts
+++ b/arch/arm/dts/imx6ul-ts7100.dts
@@ -375,10 +375,6 @@
 	status = "disabled";
 };
 
-&wdog1 {
-	status = "disabled";
-};
-
 &weim {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_weim_fpga &pinctrl_weim_cs0>;


### PR DESCRIPTION
Fixes duplicate wdog1 node and fixes wdog behavior on the TS-7100.