### PR TITLE
board: ts7100/ts7180/ts7250v3 WDT fixes

### DIFF
--- a/arch/arm/dts/imx6ul-ts7100.dts
+++ b/arch/arm/dts/imx6ul-ts7100.dts
@@ -375,10 +375,6 @@
 	status = "disabled";
 };
 
-&wdog1 {
-	status = "disabled";
-};
-
 &weim {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_weim_fpga &pinctrl_weim_cs0>;

--- a/arch/arm/dts/imx6ul-ts7250v3.dts
+++ b/arch/arm/dts/imx6ul-ts7250v3.dts
@@ -513,10 +513,6 @@
 	status = "disabled";
 };
 
-&wdog1 {
-	status = "disabled";
-};
-
 &weim {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_weim_fpga &pinctrl_weim_cs0>;
@@ -873,7 +869,6 @@
 				MX6UL_PAD_SNVS_TAMPER8__GPIO5_IO08	0x1a020 /* EN_CL_2 */
 				MX6UL_PAD_SNVS_TAMPER9__GPIO5_IO09	0x1a020 /* EN_CL_3 */
 				MX6UL_PAD_LCD_CLK__GPIO3_IO00		0x1b020 /* EN_USB_5V */
-				MX6UL_PAD_LCD_RESET__WDOG1_WDOG_ANY	0x1a020 /* WDOG# */
 				MX6UL_PAD_NAND_RE_B__GPIO4_IO00		0x1b029 /* FPGA_FLASH_SELECT */
 				MX6UL_PAD_NAND_WE_B__GPIO4_IO01		0x1b029 /* DETECT_94-120 */
 			>;

--- a/board/technologic/ts7100/ts7100.c
+++ b/board/technologic/ts7100/ts7100.c
@@ -179,6 +179,10 @@ static iomux_v3_cfg_t const misc_pads[] = {
 	MX6_PAD_SNVS_TAMPER9__GPIO5_IO09 | MUX_PAD_CTRL(MISC_PAD_CTRL),
 };
 
+static iomux_v3_cfg_t const wdog_pads[] = {
+	MX6_PAD_LCD_RESET__WDOG1_WDOG_ANY | MUX_PAD_CTRL(NO_PAD_CTRL),
+};
+
 #if !defined(CONFIG_SPL) || defined(CONFIG_SPL_BUILD)
 static void setup_iomux_uart(void)
 {
@@ -464,6 +468,8 @@ int board_early_init_f(void)
 #if !defined(CONFIG_SPL) || defined(CONFIG_SPL_BUILD)
 	setup_iomux_uart();
 #endif
+
+	imx_iomux_v3_setup_multiple_pads(wdog_pads, ARRAY_SIZE(wdog_pads));
 
 	imx_iomux_v3_setup_multiple_pads(fpga_jtag_pads,
 		ARRAY_SIZE(fpga_jtag_pads));

--- a/board/technologic/ts7180/ts7180.c
+++ b/board/technologic/ts7180/ts7180.c
@@ -125,6 +125,10 @@ static iomux_v3_cfg_t const uart1_pads[] = {
 	MX6_PAD_UART1_RX_DATA__UART1_DCE_RX | MUX_PAD_CTRL(UART_PAD_CTRL),
 };
 
+static iomux_v3_cfg_t const wdog_pads[] = {
+	MX6_PAD_LCD_RESET__WDOG1_WDOG_ANY | MUX_PAD_CTRL(NO_PAD_CTRL),
+};
+
 static void setup_iomux_uart(void)
 {
 	imx_iomux_v3_setup_multiple_pads(uart1_pads, ARRAY_SIZE(uart1_pads));
@@ -274,6 +278,7 @@ static int setup_fec(void)
 int board_early_init_f(void)
 {
 	setup_iomux_uart();
+	imx_iomux_v3_setup_multiple_pads(wdog_pads, ARRAY_SIZE(wdog_pads));
 
 	imx_iomux_v3_setup_multiple_pads(fpga_jtag_pads,
 					 ARRAY_SIZE(fpga_jtag_pads));

--- a/board/technologic/ts7250v3/ts7250v3.c
+++ b/board/technologic/ts7250v3/ts7250v3.c
@@ -56,6 +56,10 @@ DECLARE_GLOBAL_DATA_PTR;
 	PAD_CTL_PUS_47K_UP  | PAD_CTL_SPEED_LOW |		\
 	PAD_CTL_DSE_80ohm   | PAD_CTL_SRE_FAST  | PAD_CTL_HYS)
 
+static iomux_v3_cfg_t const wdog_pads[] = {
+	MX6_PAD_LCD_RESET__WDOG1_WDOG_ANY | MUX_PAD_CTRL(NO_PAD_CTRL),
+};
+
 int is_mfg(void)
 {
 	return is_boot_from_usb();
@@ -228,6 +232,7 @@ int board_init(void)
 {
 	/* Address of boot parameters */
 	gd->bd->bi_boot_params = PHYS_SDRAM + 0x100;
+	imx_iomux_v3_setup_multiple_pads(wdog_pads, ARRAY_SIZE(wdog_pads));
 
 #ifdef CONFIG_FEC_MXC
 	reset_phy();


### PR DESCRIPTION
This fixes the watchdog resets on the TS-7180 and TS-7100.  A 'reset' would reproduce it stalling on the TS-7100 without this change.  

Before this change, LCD_RESET is a GPIO
```
=> md.l 0x020e0114 1
020e0114: 00000005
```

After this change, it should return 0x4 for the WDOG1_ANY mode.

Tested on TS-7100/TS-7180/TS-7250-V3.